### PR TITLE
fix: prefer local subdirectory over zoxide for cd autojump

### DIFF
--- a/nix/home/zoxide.nix
+++ b/nix/home/zoxide.nix
@@ -27,11 +27,15 @@
         zle accept-line
         return
       fi
-      # Try zoxide
-      local dir
-      dir=$(zoxide query --exclude "$PWD" -- "$cmd" 2>/dev/null)
-      if [[ -n "$dir" ]]; then
-        BUFFER="cd $dir"
+      # Prefer local subdirectory, then fall back to zoxide
+      if [[ -d "$cmd" ]]; then
+        BUFFER="cd $cmd"
+      else
+        local dir
+        dir=$(zoxide query --exclude "$PWD" -- "$cmd" 2>/dev/null)
+        if [[ -n "$dir" ]]; then
+          BUFFER="cd $dir"
+        fi
       fi
       zle accept-line
     }
@@ -44,8 +48,8 @@
       # Skip if empty, has spaces, or is already a valid command
       [[ -z "$cmd" || "$cmd" == *" "* ]] && return
       type "$cmd" &>/dev/null && return
-      # Check zoxide and highlight in green if match found
-      if zoxide query --exclude "$PWD" -- "$cmd" &>/dev/null 2>&1; then
+      # Highlight in green if local dir exists or zoxide matches
+      if [[ -d "$cmd" ]] || zoxide query --exclude "$PWD" -- "$cmd" &>/dev/null 2>&1; then
         region_highlight+=("0 ''${#cmd} fg=green,bold")
       fi
     }


### PR DESCRIPTION
## Goal
Fix zoxide jumping to wrong directories when a local subdirectory matches.

## Changes
- When a directory name exists under the current directory, cd into it directly instead of querying zoxide
- Fixes cases where zoxide would jump to a different project (e.g., typing `main` in LMS jumping to SLS)