### PR TITLE
feat: gws rebase fallback and gpo alias

### DIFF
--- a/nix/home/scripts/git-worktree-sync.sh
+++ b/nix/home/scripts/git-worktree-sync.sh
@@ -119,15 +119,26 @@ sync_repo() {
       local status_parts=()
 
       if [[ "$behind" -gt 0 && "$ahead" -gt 0 ]]; then
-        status_parts+=("${YELLOW}diverged${RESET} ${DIM}(ahead $ahead, behind $behind)${RESET}")
-        ((stale_count++)) || true
+        # Diverged — try rebase to replay local commits on top of upstream
+        if git -C "$wt_path" pull --rebase --quiet 2>/dev/null; then
+          status_parts+=("${GREEN}rebased${RESET} ${DIM}(ahead $ahead, pulled $behind)${RESET}")
+          ((updated_count++)) || true
+        else
+          git -C "$wt_path" rebase --abort 2>/dev/null || true
+          status_parts+=("${YELLOW}diverged${RESET} ${DIM}(ahead $ahead, behind $behind — rebase failed)${RESET}")
+          ((stale_count++)) || true
+        fi
       elif [[ "$behind" -gt 0 ]]; then
-        # Try to fast-forward
+        # Try fast-forward first, fall back to rebase
         if git -C "$wt_path" merge --ff-only "$upstream" --quiet 2>/dev/null; then
           status_parts+=("${GREEN}pulled${RESET} ${DIM}($behind commits)${RESET}")
           ((updated_count++)) || true
+        elif git -C "$wt_path" pull --rebase --quiet 2>/dev/null; then
+          status_parts+=("${GREEN}rebased${RESET} ${DIM}($behind commits)${RESET}")
+          ((updated_count++)) || true
         else
-          status_parts+=("${YELLOW}behind $behind${RESET} ${DIM}(ff failed)${RESET}")
+          git -C "$wt_path" rebase --abort 2>/dev/null || true
+          status_parts+=("${YELLOW}behind $behind${RESET} ${DIM}(rebase failed)${RESET}")
           ((stale_count++)) || true
         fi
       elif [[ "$ahead" -gt 0 ]]; then
@@ -183,12 +194,25 @@ sync_repo() {
       ahead=$(echo "$ab" | awk '{print $1}')
       behind=$(echo "$ab" | awk '{print $2}')
 
-      if [[ "$behind" -gt 0 ]]; then
+      if [[ "$behind" -gt 0 && "$ahead" -gt 0 ]]; then
+        if git -C "$wt_path" pull --rebase --quiet 2>/dev/null; then
+          echo -e "  [${GREEN}rebased${RESET} ${DIM}(ahead $ahead, pulled $behind)${RESET}] $wt_dir ${DIM}($wt_branch)${RESET}"
+          ((updated_count++)) || true
+        else
+          git -C "$wt_path" rebase --abort 2>/dev/null || true
+          echo -e "  [${YELLOW}diverged${RESET} ${DIM}(ahead $ahead, behind $behind — rebase failed)${RESET}] $wt_dir ${DIM}($wt_branch)${RESET}"
+          ((stale_count++)) || true
+        fi
+      elif [[ "$behind" -gt 0 ]]; then
         if git -C "$wt_path" merge --ff-only "$upstream" --quiet 2>/dev/null; then
           echo -e "  [${GREEN}pulled${RESET} ${DIM}($behind commits)${RESET}] $wt_dir ${DIM}($wt_branch)${RESET}"
           ((updated_count++)) || true
+        elif git -C "$wt_path" pull --rebase --quiet 2>/dev/null; then
+          echo -e "  [${GREEN}rebased${RESET} ${DIM}($behind commits)${RESET}] $wt_dir ${DIM}($wt_branch)${RESET}"
+          ((updated_count++)) || true
         else
-          echo -e "  [${YELLOW}behind $behind${RESET}] $wt_dir ${DIM}($wt_branch)${RESET}"
+          git -C "$wt_path" rebase --abort 2>/dev/null || true
+          echo -e "  [${YELLOW}behind $behind${RESET} ${DIM}(rebase failed)${RESET}] $wt_dir ${DIM}($wt_branch)${RESET}"
           ((stale_count++)) || true
         fi
       else

--- a/nix/home/shell.nix
+++ b/nix/home/shell.nix
@@ -88,6 +88,7 @@
       glog = "git log --graph --pretty=format:'%C(bold red)%h%Creset -%C(bold yellow)%d%Creset %s %C(bold green)(%cr) %C(bold blue)<%an>%Creset' --abbrev-commit";
       ggstat = "git log --graph --pretty=format:'%C(bold red)%h%Creset -%C(bold yellow)%d%Creset %s %C(bold green)(%cr) %C(bold blue)<%an>%Creset' --abbrev-commit --stat";
       gcp = "git cherry-pick";
+      gpo = "git pull origin $(git branch --show-current)";
 
       # Git utilities
       gff = "git flow feature";

--- a/nix/home/version-control.nix
+++ b/nix/home/version-control.nix
@@ -17,6 +17,7 @@
     settings = {
       color.ui = true;
       push.default = "simple";
+      push.autoSetupRemote = true;
       init.defaultBranch = "main";
     };
   };


### PR DESCRIPTION
## Goal
Improve git worktree sync (`gws`) to handle diverged branches automatically, and add a shorthand for pulling from origin using the current branch name.

## Changes
- **gws rebase fallback**: When worktrees have diverged branches (ahead + behind), `gws` now attempts `pull --rebase` before giving up. Falls back gracefully with `rebase --abort` on conflict. Also applies rebase as fallback when fast-forward fails on behind-only branches.
- **gpo alias**: `git pull origin $(git branch --show-current)` — pull from origin using current branch name when upstream isn't set.
- **push.autoSetupRemote**: Auto-sets upstream on first push so plain `git pull` works afterward.

## Test plan
- [ ] Rebuild home-manager and verify `gpo` alias works
- [ ] Run `gws` on a repo with a diverged branch to confirm rebase behavior
- [ ] Verify `push.autoSetupRemote` is active via `git config --get push.autoSetupRemote`