### PR TITLE
feat: configure nvimdiff as git merge tool

### DIFF
--- a/lazy-vim/lua/config/keymaps.lua
+++ b/lazy-vim/lua/config/keymaps.lua
@@ -122,6 +122,11 @@ vim.keymap.set("n", "<Esc>", "<cmd>noh<CR><Esc>", { desc = "Clear search and esc
 -- Escape terminal mode with <Esc>
 vim.keymap.set("t", "<Esc>", "<C-\\><C-n>", { desc = "Exit terminal mode" })
 
+-- Git merge tool (nvimdiff)
+vim.keymap.set("n", "<leader>ml", "<cmd>diffget LOCAL<CR>", { desc = "Accept LOCAL" })
+vim.keymap.set("n", "<leader>mr", "<cmd>diffget REMOTE<CR>", { desc = "Accept REMOTE" })
+vim.keymap.set("n", "<leader>mb", "<cmd>diffget BASE<CR>", { desc = "Accept BASE" })
+
 -- IDE-like buffer closing (:q closes buffer, :qa quits vim)
 local function close_buffer()
   local buffers = vim.fn.getbufinfo({ buflisted = 1 })

--- a/lazy-vim/lua/config/keymaps.lua
+++ b/lazy-vim/lua/config/keymaps.lua
@@ -122,10 +122,13 @@ vim.keymap.set("n", "<Esc>", "<cmd>noh<CR><Esc>", { desc = "Clear search and esc
 -- Escape terminal mode with <Esc>
 vim.keymap.set("t", "<Esc>", "<C-\\><C-n>", { desc = "Exit terminal mode" })
 
--- Git merge tool (nvimdiff)
-vim.keymap.set("n", "<leader>ml", "<cmd>diffget LOCAL<CR>", { desc = "Accept LOCAL" })
-vim.keymap.set("n", "<leader>mr", "<cmd>diffget REMOTE<CR>", { desc = "Accept REMOTE" })
-vim.keymap.set("n", "<leader>mb", "<cmd>diffget BASE<CR>", { desc = "Accept BASE" })
+-- Git merge conflicts (nvimdiff) — which-key group label
+require("which-key").add({ { "<leader>gm", group = "merge conflicts" } })
+vim.keymap.set("n", "<leader>gml", "<cmd>diffget LOCAL<CR>", { desc = "Accept LOCAL" })
+vim.keymap.set("n", "<leader>gmr", "<cmd>diffget REMOTE<CR>", { desc = "Accept REMOTE" })
+vim.keymap.set("n", "<leader>gmb", "<cmd>diffget BASE<CR>", { desc = "Accept BASE" })
+vim.keymap.set("n", "<leader>gmn", "]c", { desc = "Next conflict" })
+vim.keymap.set("n", "<leader>gmp", "[c", { desc = "Prev conflict" })
 
 -- IDE-like buffer closing (:q closes buffer, :qa quits vim)
 local function close_buffer()

--- a/nix/home/version-control.nix
+++ b/nix/home/version-control.nix
@@ -18,6 +18,8 @@
       color.ui = true;
       push.default = "simple";
       init.defaultBranch = "main";
+      merge.tool = "nvimdiff";
+      mergetool.keepBackup = false;
     };
   };
 


### PR DESCRIPTION
## Goal
Configure nvimdiff as the default git merge tool with convenient LazyVim keybindings for resolving conflicts.

## Changes
- **nix/home/version-control.nix**: Add `merge.tool = "nvimdiff"` and `mergetool.keepBackup = false` to git settings
- **lazy-vim/lua/config/keymaps.lua**: Add `<leader>ml` (accept LOCAL), `<leader>mr` (accept REMOTE), `<leader>mb` (accept BASE) keymaps for diff mode

## Test plan
- [ ] Run `home-manager switch` and verify `~/.config/git/config` has merge.tool and mergetool settings
- [ ] Open nvim and confirm `<leader>ml/mr/mb` keymaps are registered (`:map <leader>m`)
- [ ] Test with a real merge conflict using `git mergetool`