### PR TITLE
feat: add gmt alias for git mergetool

### DIFF
--- a/nix/home/shell.nix
+++ b/nix/home/shell.nix
@@ -85,6 +85,7 @@
       gl = "git log";
       gt = "git tag";
       gm = "git merge";
+      gmt = "git mergetool";
       glog = "git log --graph --pretty=format:'%C(bold red)%h%Creset -%C(bold yellow)%d%Creset %s %C(bold green)(%cr) %C(bold blue)<%an>%Creset' --abbrev-commit";
       ggstat = "git log --graph --pretty=format:'%C(bold red)%h%Creset -%C(bold yellow)%d%Creset %s %C(bold green)(%cr) %C(bold blue)<%an>%Creset' --abbrev-commit --stat";
       gcp = "git cherry-pick";


### PR DESCRIPTION
## Goal
Add shell alias for quick access to git mergetool.

## Changes
- Add `gmt` alias mapping to `git mergetool` in `shell.nix`, alongside existing git aliases