### PR TITLE
fix: add --verbose flag to claude aliases

### DIFF
--- a/nix/home/shell.nix
+++ b/nix/home/shell.nix
@@ -44,10 +44,10 @@
       b = "bat";
       g = "git";
       t = "tree";
-      c = "claude";
+      c = "claude --verbose";
 
       # Claude dangerous mode
-      cdsp = "claude --dangerously-skip-permissions";
+      cdsp = "claude --dangerously-skip-permissions --verbose";
 
       # Home Manager
       tks = "tmux kill-server";


### PR DESCRIPTION
## Goal
Enable verbose output by default when running Claude from the terminal.

## Changes
- Add `--verbose` flag to `c` (claude) and `cdsp` (claude dangerous mode) shell aliases