### PR TITLE
feat: disable tmux window list from status bar

### DIFF
--- a/nix/home/tmux/default.nix
+++ b/nix/home/tmux/default.nix
@@ -25,7 +25,7 @@ let
 
   features = {
     panes = true;
-    windows = true;
+    windows = false;
     sessions = true;
   };
 
@@ -38,10 +38,11 @@ let
   windows = import ./windows.nix vars;
   sessions = import ./sessions.nix vars;
 
-  # Merge catppuccin config from theme + enabled features
+  # Merge catppuccin config from theme + features
+  # Window config is always included — catppuccin needs it to initialize status modules
   catppuccinConfig = lib.concatStrings [
     themeModule.catppuccinConfig
-    (lib.optionalString features.windows windows.catppuccinConfig)
+    windows.catppuccinConfig
     (lib.optionalString features.sessions sessions.catppuccinConfig)
   ];
 
@@ -72,6 +73,10 @@ let
     ${themeModule.layout}
     ${mkStatusSide "left" statusLeft}
     ${mkStatusSide "right" statusRight}
+    ${lib.optionalString (!features.windows) ''
+    set -g window-status-format " "
+    set -g window-status-current-format " "
+    ''}
   '';
 
 in


### PR DESCRIPTION
## Summary
- Set `features.windows = false` to hide window list and remove window keybindings
- Always include catppuccin window config — the plugin needs it to properly initialize status modules
- Use `window-status-format " "` (space, not empty) to hide the list — empty strings break tmux's `status-right` rendering

## Context
Sessions + panes is a better workflow; the window list in the status bar was unused clutter. Setting `features.windows = false` is easily revertible if needed.

## Test plan
- [ ] Rebuild and verify no window list appears in tmux status bar
- [ ] Verify right side pills (session + meeting) still render correctly
- [ ] Verify window keybindings (Alt+j/k, Alt+1-9) are removed
- [ ] Verify pane and session keybindings still work