### PR TITLE
feat: improve tmux session lifecycle behavior

### DIFF
--- a/nix/home/shell.nix
+++ b/nix/home/shell.nix
@@ -155,13 +155,6 @@
         fi
       '')
       ''
-        # Auto-start tmux (attach existing or prompt for new session name)
-        if [[ -z "$TMUX" ]] && command -v tmux &> /dev/null && [[ $- == *i* ]]; then
-          if ! tmux attach-session 2>/dev/null; then
-            read "name?New tmux session name: "
-            tmux new-session -s "''${name:-default}"
-          fi
-        fi
 
         # Custom functions
         # Remove any legacy alias so the function always wins.

--- a/nix/home/tmux/core.nix
+++ b/nix/home/tmux/core.nix
@@ -11,4 +11,7 @@
 
   # Prevent automatic renaming from overriding manual names
   set-option -g automatic-rename off
+
+  # Switch to another session instead of exiting when a session is destroyed
+  set -g detach-on-destroy no-detached
 ''


### PR DESCRIPTION
## Summary
- Remove auto-start tmux on new terminal — opens a plain shell instead
- Add `detach-on-destroy no-detached` — closing a session switches to the next one instead of exiting tmux

## Test plan
- [ ] Opening a new terminal window gives a plain shell (no tmux)
- [ ] Killing a session with other sessions open switches to the next session
- [ ] Killing the last session exits tmux as expected