### PR TITLE
chore: update git email to personal domain

### DIFF
--- a/nix/home/version-control.nix
+++ b/nix/home/version-control.nix
@@ -10,9 +10,8 @@
 
   programs.git = {
     enable = true;
-    # Uncomment and fill in your details:
-    # userName = "Ivan";
-    # userEmail = "your@email.com";
+    userName = "iamonzon";
+    userEmail = "github@iamonzon.dev";
 
     settings = {
       color.ui = true;


### PR DESCRIPTION
## Goal
Update git user email to personal domain for all future commits.

## Changes
- Update `userEmail` from `ivan@boddlelearning.com` to `github@iamonzon.dev` in `nix/home/version-control.nix`

## Test plan
- [ ] Run `home-manager switch` and verify `git config user.email` outputs `github@iamonzon.dev`