### PR TITLE
feat: add Hammerspoon config (timer, calendar, progress bar, tooltip)

### DIFF
--- a/hammerspoon/IDEATION.md
+++ b/hammerspoon/IDEATION.md
@@ -1,0 +1,190 @@
+# Calendar Progress Bar — Plan & Implementation Notes
+
+A thin always-on-top horizontal line at the bottom of the macOS screen that
+fills left-to-right as time elapses against the current calendar event (or a
+manually-triggered timer). Visual ancestor: the Reveal.js progress bar that
+the Obsidian Advanced Slides plugin shows during a slideshow.
+
+---
+
+## 1. Goal
+
+Make "how much time is left in this thing I'm doing" *peripherally visible*
+without requiring a glance at a clock and a subtraction. The brain reads a
+filling bar faster than it reads `14:23 / 30:00`, and an always-on overlay
+removes the "remember to check" step.
+
+## 2. Alternatives considered, and why they were dropped
+
+| Candidate                 | Reason dropped                                                                 |
+|---------------------------|--------------------------------------------------------------------------------|
+| tmux status bar           | One character row tall; competes with existing status content; only visible inside tmux. Wrong shape for a full-screen ambient cue. |
+| Übersicht widget          | Sits *behind* application windows by default. Fighting that defeats the purpose. |
+| SwiftBar / xbar menu bar  | Wrong primitive — menu bar is a strip of icons, not a line you can fill.       |
+| Native SwiftUI app        | Correct, polished, but two evenings of entitlements and signing for a 3 px line. |
+| Electron overlay          | Heavy runtime cost for a trivial visual.                                       |
+
+**Choice: Hammerspoon.** `hs.canvas` draws a borderless, click-through,
+always-on-top, ignores-Spaces overlay in ~30 lines of Lua. No code signing,
+no App Store, no Xcode.
+
+## 3. Architecture
+
+```
+┌────────────────────────────────────────────────────────────┐
+│                    user space                              │
+│                                                            │
+│   ⌃⌥⌘T ─►  hs.dialog ─►  manualTimer state                 │
+│                                  │                         │
+│   icalBuddy ─►  refreshEvent ─►  currentEvent state        │
+│   (every 60s)                    │                         │
+│                                  ▼                         │
+│                          activeSource()                    │
+│                          (manual wins if both)             │
+│                                  │                         │
+│                                  ▼                         │
+│   hs.timer (1s) ─►  tick() ─►  hs.canvas frame update      │
+│                                                            │
+└────────────────────────────────────────────────────────────┘
+```
+
+Two independent loops, decoupled cadences:
+
+- **Calendar refresh loop** — runs `icalBuddy eventsNow` every 60 s.
+  Polling, not push, because there is no event-bus from Calendar.app worth
+  the integration cost.
+- **Render loop** — `tick()` runs every 1 s. It picks an active source,
+  computes `elapsed / total`, and sets the filled rectangle's width as a
+  percentage string. Cheap; no calendar calls in the render path.
+
+Source priority: **manual timer overrides calendar event** when both are
+active. Rationale: the user invoking the hotkey is a fresher act of
+intention than whatever was scheduled.
+
+## 4. Calendar integration: `icalBuddy`
+
+Reads directly from the macOS Calendar database. No OAuth, no API keys —
+just one Calendar permission prompt the first time. Anything that already
+syncs into Calendar.app (Google, Exchange, iCloud, CalDAV) becomes
+queryable for free.
+
+```bash
+icalBuddy -nc -b "" \
+  -iep 'datetime,title' \
+  -eep 'notes,url,location,attendees' \
+  -df "%Y-%m-%d" -tf "%H:%M:%S" \
+  -po 'datetime,title' \
+  eventsNow
+```
+
+Output format varies by icalBuddy version and system locale. The parser
+in the script handles the most common shape; the regex is the part most
+likely to need adjustment per machine.
+
+**Filter:** events longer than `MAX_EVENT_HOURS` (default 20) are
+discarded. This silently kills the obvious problem of an all-day "Office
+Hours" block making the bar tick forward by 0.07 % per minute.
+
+## 5. Manual timer mode
+
+Hotkeys:
+
+- `⌃⌥⌘T` → text prompt → start
+- `⌃⌥⌘.` → cancel running timer
+
+Input parser accepts:
+
+| Input          | Meaning            |
+|----------------|--------------------|
+| `25`           | 25 minutes         |
+| `25 deep work` | 25 minutes, label "deep work" |
+| `1h30`         | 90 minutes         |
+| `1:30`         | 90 minutes         |
+| `90s`          | 1.5 minutes        |
+
+On completion: system notification + the bar fades to invisible, then
+falls back to whatever calendar event is current (if any).
+
+**Visual distinction:** manual timer renders in a blue palette,
+calendar event renders in a green palette. Both escalate through amber
+→ red as they near completion. At a glance, you can tell which source
+is driving the bar.
+
+## 6. Failure modes and what we did about each
+
+| Failure mode                              | Mitigation                                                                 |
+|-------------------------------------------|----------------------------------------------------------------------------|
+| All-day / very long events flood the bar  | Discard events longer than `MAX_EVENT_HOURS` (20)                          |
+| Multi-display setup                       | Currently primary display only. To extend, loop `hs.screen.allScreens()`   |
+| Notebook notch                            | `frame()` already excludes menu bar area; bar placed below it              |
+| Native fullscreen apps                    | OS-level limitation; overlay can't appear over true exclusive fullscreen   |
+| Overlapping events                        | Parser picks first event icalBuddy lists. Decide a real rule before this bites you. |
+| Calendar permission denied                | icalBuddy returns empty; bar simply stays invisible                        |
+| Hammerspoon timer GC                      | **Critical.** Timer and watcher handles MUST be held at module scope or Lua GC collects them mid-session and the bar silently freezes. Causes the "worked fine then stopped halfway" symptom. |
+| Runtime error inside `tick()`             | Wrap in `pcall`, log to `hs.console`. Otherwise an exception can kill the timer loop. |
+| icalBuddy output format drift             | Parser regex is the first thing to touch when the bar stops reflecting reality |
+| Locale decimal separator in percentages   | Theoretical concern in `es-CL`-style locales. `tostring(50.5)` in standard Lua is locale-independent; unlikely to bite, but the fallback is `string.format("%.2f", pct*100)`. |
+
+## 7. Open assumptions worth re-examining at the 30-day mark
+
+These are the design bets that will look right or wrong only with usage,
+not analysis:
+
+1. **Calendar reflects reality.** This whole thing is useful in proportion
+   to how religiously the user time-blocks. If 80 % of focused work
+   happens *between* scheduled meetings, the bar will be empty during the
+   work that most benefits from a timer, and full during meetings (where
+   the visual nudge matters less). Manual mode partially compensates,
+   but only if the user remembers to trigger it.
+2. **Peripheral motion is helpful, not anxiogenic.** Same data, opposite
+   nervous-system response across users. If after a week the bar is more
+   stressor than aid, the fix isn't tuning — it's switching to
+   on-demand-only mode (manual hotkey, no calendar polling).
+3. **The bottom edge is the right placement.** Top-of-screen places the
+   bar adjacent to the menu bar (busy area). Bottom places it adjacent to
+   the Dock (also busy if Dock is shown). On a notched MacBook with
+   auto-hide Dock, bottom is cleanest. On an external monitor without a
+   Dock, both work.
+4. **1 s tick is the right cadence.** Faster is wasteful for a bar that
+   moves 0.07 % per second on a 30-min event. Slower starts to feel laggy
+   on short timers. 1 s is the well-trodden default.
+5. **Manual overrides calendar, not the other way around.** Tested
+   intuitively; if it turns out the user starts manual timers *during*
+   meetings and wants the meeting bar instead, flip the precedence in
+   `activeSource()`.
+
+## 8. Future extensions (only if real usage demands them)
+
+These are explicitly *not* in v1 because each adds bug surface that needs
+to be justified by real friction, not anticipated friction:
+
+- **Pause / resume.** Adds state bugs around sleep, expiry-while-paused,
+  multiple-pauses. Default discipline: if interrupted, restart.
+- **Per-display bars.** One canvas per screen. ~10 extra lines but
+  doubles the surface area for screen-watcher edge cases.
+- **Custom palettes per calendar.** Show e.g. blue for "Focus" calendar,
+  red for "Meetings" calendar. Requires reading the source calendar from
+  icalBuddy and a config map.
+- **End-of-event "5 min remaining" pulse.** A short animation when
+  `pct > 0.83`. Easy. Adds urgency cue without adding text.
+- **History log.** Append every completed timer to a markdown file.
+  Useful for review; trivial to add; deferred until requested.
+
+## 9. Installation summary
+
+```bash
+brew install hammerspoon ical-buddy
+```
+
+1. Drop the script into `~/.hammerspoon/init.lua`.
+2. Adjust `ICALBUDDY_PATH` if not on Apple Silicon.
+3. Run the icalBuddy command above once from Terminal to verify output
+   format and trigger the Calendar permission prompt.
+4. Launch Hammerspoon, grant Accessibility permission.
+5. Menu icon → Reload Config.
+6. Test with `⌃⌥⌘T` → `1` (a 1-minute timer) to confirm the bar fills
+   end-to-end and the completion notification fires.
+
+If anything misbehaves: Hammerspoon menu → Console, reload, watch for
+errors. The Console is the only place runtime errors surface; everything
+else is silent.

--- a/hammerspoon/ambient/.gitignore
+++ b/hammerspoon/ambient/.gitignore
@@ -1,0 +1,4 @@
+# User-supplied audio files — kept local, not versioned.
+*
+!.gitkeep
+!.gitignore

--- a/hammerspoon/core/chooser.lua
+++ b/hammerspoon/core/chooser.lua
@@ -1,0 +1,27 @@
+-- Module chooser. Hotkey-driven hs.chooser listing every loaded module
+-- with its status() subtitle. Selecting a row reloads that module.
+
+local M = {}
+
+local function rowsFor(registry)
+  local rows = {}
+  for _, name in ipairs(registry.list()) do
+    rows[#rows + 1] = {
+      text    = name,
+      subText = registry.status(name),
+      name    = name,
+    }
+  end
+  return rows
+end
+
+function M.open(registry)
+  local chooser = hs.chooser.new(function(choice)
+    if choice and choice.name then registry.reload(choice.name) end
+  end)
+  chooser:choices(rowsFor(registry))
+  chooser:placeholderText("reload module")
+  chooser:show()
+end
+
+return M

--- a/hammerspoon/core/config.lua
+++ b/hammerspoon/core/config.lua
@@ -1,0 +1,8 @@
+-- Global constants. A value belongs here only if more than one module
+-- would otherwise need to duplicate it. Module-specific tuning stays
+-- inside the module that owns it.
+
+return {
+  TICK_SECONDS = 1,
+  BAR_POSITION = "bottom",  -- "top" or "bottom"
+}

--- a/hammerspoon/core/registry.lua
+++ b/hammerspoon/core/registry.lua
@@ -1,0 +1,134 @@
+-- Module registry. Loads modules, holds strong refs to every hs.* handle
+-- they create (the GC pin from IDEATION.md §6), and provides hot reload
+-- without re-bootstrapping Hammerspoon.
+
+local config = require("core.config")
+
+local M = {}
+
+-- name -> { mod, inst, refs = { hs.timer | hs.canvas | hs.screen.watcher | hs.hotkey, ... } }
+local instances = {}
+
+-- Weak-keyed set of every canvas ever handed out, so we can sweep
+-- orphans if a module's stop() forgets one before reload.
+local seenCanvases = setmetatable({}, { __mode = "k" })
+
+local function classify(handle)
+  if type(handle) ~= "userdata" and type(handle) ~= "table" then return nil end
+  local s = tostring(handle)
+  if s:find("hs.canvas",         1, true) then return "canvas" end
+  if s:find("hs.hotkey",         1, true) then return "hotkey" end
+  if s:find("hs.timer",          1, true) then return "timer_or_watcher" end
+  if s:find("hs.screen.watcher", 1, true) then return "timer_or_watcher" end
+  return nil
+end
+
+local function releaseRef(handle)
+  local kind = classify(handle)
+  if kind == "canvas" then
+    pcall(function() handle:delete() end)
+  elseif kind == "hotkey" then
+    pcall(function() handle:delete() end)
+  elseif kind == "timer_or_watcher" then
+    pcall(function() handle:stop() end)
+  end
+end
+
+local function sweepOrphanCanvases()
+  for c, _ in pairs(seenCanvases) do
+    pcall(function() c:delete() end)
+    seenCanvases[c] = nil
+  end
+end
+
+local function makeCtx(name)
+  local refs = {}
+  return {
+    config = config,
+    registry = M,
+    log = function(msg) print(("[%s] %s"):format(name, msg)) end,
+    track = function(handle)
+      refs[#refs + 1] = handle
+      if classify(handle) == "canvas" then seenCanvases[handle] = true end
+      return handle
+    end,
+    _refs = refs,
+  }
+end
+
+function M.register(mod)
+  if instances[mod.name] then
+    error("registry: module already registered: " .. mod.name)
+  end
+  local ctx = makeCtx(mod.name)
+  local ok, inst = pcall(mod.start, ctx)
+  if not ok then
+    hs.alert.show(("✖ %s failed to start: %s"):format(mod.name, inst))
+    return
+  end
+  instances[mod.name] = { mod = mod, inst = inst, refs = ctx._refs }
+end
+
+function M.stop(name)
+  local entry = instances[name]
+  if not entry then return end
+  if entry.mod.stop then pcall(entry.mod.stop, entry.inst) end
+  for _, handle in ipairs(entry.refs) do releaseRef(handle) end
+  entry.inst, entry.refs = nil, nil
+end
+
+function M.reload(name)
+  local entry = instances[name]
+  if not entry then return end
+  M.stop(name)
+  sweepOrphanCanvases()
+  package.loaded["modules." .. name] = nil
+  local ok, mod = pcall(require, "modules." .. name)
+  if not ok then
+    hs.alert.show(("✖ reload %s failed: %s"):format(name, mod))
+    instances[name] = nil
+    return
+  end
+  local ctx = makeCtx(name)
+  local ok2, inst = pcall(mod.start, ctx)
+  if not ok2 then
+    hs.alert.show(("✖ %s restart failed: %s"):format(name, inst))
+    instances[name] = nil
+    return
+  end
+  instances[name] = { mod = mod, inst = inst, refs = ctx._refs }
+  hs.alert.show("↻ " .. name)
+end
+
+function M.get(name)
+  local entry = instances[name]
+  return entry and entry.inst or nil
+end
+
+function M.list()
+  local names = {}
+  for name in pairs(instances) do names[#names + 1] = name end
+  table.sort(names)
+  return names
+end
+
+function M.status(name)
+  local entry = instances[name]
+  if not entry or not entry.mod.status then return "" end
+  local ok, s = pcall(entry.mod.status, entry.inst)
+  return ok and s or "(status error)"
+end
+
+function M.sources()
+  local out = {}
+  for _, name in ipairs(M.list()) do
+    local entry = instances[name]
+    if entry.mod.source then
+      local ok, src = pcall(entry.mod.source, entry.inst)
+      if ok and src then out[#out + 1] = src end
+    end
+  end
+  return out
+end
+
+return M

--- a/hammerspoon/init.lua
+++ b/hammerspoon/init.lua
@@ -1,0 +1,16 @@
+-- Bootstrap. Loads the registry, registers each module, binds the
+-- chooser hotkey from here (so a broken module can't strand reload).
+
+require("hs.ipc")  -- enables `hs -c "..."` for programmatic reloads
+
+local registry = require("core.registry")
+local chooser  = require("core.chooser")
+
+registry.register(require("modules.timer"))
+registry.register(require("modules.calendar"))
+registry.register(require("modules.progress_bar"))
+registry.register(require("modules.tooltip"))
+
+hs.hotkey.bind({"ctrl", "alt", "cmd"}, "M", function() chooser.open(registry) end)
+
+hs.alert.show("Progress bar loaded · " .. table.concat(registry.list(), ", "))

--- a/hammerspoon/init.lua
+++ b/hammerspoon/init.lua
@@ -8,6 +8,7 @@ local chooser  = require("core.chooser")
 
 registry.register(require("modules.timer"))
 registry.register(require("modules.calendar"))
+registry.register(require("modules.ambient"))
 registry.register(require("modules.progress_bar"))
 registry.register(require("modules.tooltip"))
 

--- a/hammerspoon/lib/ambient_scanner.lua
+++ b/hammerspoon/lib/ambient_scanner.lua
@@ -1,0 +1,45 @@
+-- Pure directory scan. Filenames in the ambient/ folder are the source
+-- of truth for available moods — no hardcoded list, no manifest. Add a
+-- file, it shows up; remove it, it's gone after the next module reload.
+
+local M = {}
+
+local SUPPORTED = {
+  mp3 = true, m4a = true, wav = true, aiff = true,
+  aif = true, caf = true, flac = true,
+}
+
+local function extOf(name)
+  local ext = name:match("%.([^%.]+)$")
+  return ext and ext:lower() or nil
+end
+
+local function prettify(filename)
+  local stem = filename:match("(.+)%.[^%.]+$") or filename
+  return (stem:gsub("[_%-]+", " "))
+end
+
+-- listFn is an iterator factory (e.g. hs.fs.dir). Injected so tests can
+-- pass a fake without touching the filesystem.
+function M.scan(dir, listFn)
+  local out = {}
+  -- listFn follows the hs.fs.dir / generic-for protocol: returns
+  -- (iter, state, init). pcall it so a missing directory or permission
+  -- error gives an empty result rather than crashing module start.
+  local ok, iter, state, init = pcall(listFn, dir)
+  if not ok or type(iter) ~= "function" then return out end
+
+  for name in iter, state, init do
+    if name and name ~= "." and name ~= ".." then
+      local ext = extOf(name)
+      if ext and SUPPORTED[ext] then
+        table.insert(out, { name = prettify(name), path = dir .. "/" .. name })
+      end
+    end
+  end
+
+  table.sort(out, function(a, b) return a.name < b.name end)
+  return out
+end
+
+return M

--- a/hammerspoon/lib/duration.lua
+++ b/hammerspoon/lib/duration.lua
@@ -1,0 +1,17 @@
+-- Format integer seconds as compact human duration. Pure; tested.
+
+local M = {}
+
+local function pad2(n) return ("%02d"):format(n) end
+
+function M.formatHMS(seconds)
+  if not seconds or seconds < 0 then seconds = 0 end
+  seconds = math.floor(seconds)
+  local h = math.floor(seconds / 3600)
+  local m = math.floor((seconds % 3600) / 60)
+  local s = seconds % 60
+  if h > 0 then return ("%d:%s:%s"):format(h, pad2(m), pad2(s)) end
+  return ("%d:%s"):format(m, pad2(s))
+end
+
+return M

--- a/hammerspoon/lib/ical_parser.lua
+++ b/hammerspoon/lib/ical_parser.lua
@@ -1,0 +1,52 @@
+-- Pure parser for icalBuddy output. No hs.* deps; the I/O wrapper lives
+-- in modules/calendar.lua. Validation takes maxHours as a parameter so
+-- the function is fully deterministic and easy to test.
+
+local M = {}
+
+function M.parseDate(s)
+  local y, mo, d, h, mi, se = (s or ""):match("(%d+)-(%d+)-(%d+) (%d+):(%d+):(%d+)")
+  if not y then return nil end
+  return os.time({ year = y, month = mo, day = d, hour = h, min = mi, sec = se })
+end
+
+function M.tryLongFormat(out)
+  return out:match(
+    "(%d%d%d%d%-%d%d%-%d%d %d%d:%d%d:%d%d)%s*%-%s*(%d%d%d%d%-%d%d%-%d%d %d%d:%d%d:%d%d)"
+  )
+end
+
+function M.tryShortFormat(out)
+  local datePart, sTime, eTime = out:match(
+    "(%d%d%d%d%-%d%d%-%d%d) (%d%d:%d%d:%d%d).-(%d%d:%d%d:%d%d)"
+  )
+  if not datePart then return nil end
+  return datePart .. " " .. sTime, datePart .. " " .. eTime
+end
+
+function M.extractTitle(out)
+  local t = out:match("\n%s*([^\n]+)") or "event"
+  return t:gsub("^%s+", ""):gsub("%s+$", "")
+end
+
+function M.parseOutput(out)
+  if not out or out == "" then return nil end
+  local startStr, endStr = M.tryLongFormat(out)
+  if not startStr then startStr, endStr = M.tryShortFormat(out) end
+  if not startStr then return nil end
+  return {
+    startEpoch = M.parseDate(startStr),
+    endEpoch   = M.parseDate(endStr),
+    title      = M.extractTitle(out),
+  }
+end
+
+function M.validateEvent(evt, maxHours)
+  if not evt then return nil end
+  if not (evt.startEpoch and evt.endEpoch) then return nil end
+  if evt.endEpoch <= evt.startEpoch then return nil end
+  if (evt.endEpoch - evt.startEpoch) > (maxHours or 20) * 3600 then return nil end
+  return evt
+end
+
+return M

--- a/hammerspoon/lib/timer_parser.lua
+++ b/hammerspoon/lib/timer_parser.lua
@@ -1,0 +1,49 @@
+-- Pure parser for the manual-timer input string. No hs.* deps so it can
+-- be unit-tested under standalone Lua. The module that owns I/O is
+-- modules/timer.lua.
+
+local M = {}
+
+local function trim(s) return (s or ""):gsub("^%s+", ""):gsub("%s+$", "") end
+
+local function matchColon(s)
+  local h, m = s:match("^(%d+):(%d+)$")
+  return h and (tonumber(h) * 60 + tonumber(m)) or nil
+end
+
+local function matchSeconds(s)
+  local ss = s:match("^(%d+)s$")
+  return ss and (tonumber(ss) / 60) or nil
+end
+
+local function matchHourMinute(s)
+  local hh = s:match("^(%d+)h")
+  local mm = s:match("h(%d+)m?$") or s:match("^(%d+)m$")
+  if not (hh or mm) then return nil end
+  return (tonumber(hh) or 0) * 60 + (tonumber(mm) or 0)
+end
+
+local function matchBareMinutes(s)
+  return s:match("^(%d+)$") and tonumber(s) or nil
+end
+
+M.MATCHERS = { matchColon, matchSeconds, matchHourMinute, matchBareMinutes }
+
+function M.parseInput(raw)
+  local s = trim(raw)
+  if s == "" then return nil end
+  local timepart, label = s:match("^(%S+)%s+(.+)$")
+  if not timepart then timepart, label = s, "Focus" end
+  for _, fn in ipairs(M.MATCHERS) do
+    local minutes = fn(timepart)
+    if minutes and minutes > 0 then return minutes, label end
+  end
+  return nil
+end
+
+function M.durationLabel(minutes)
+  if minutes >= 1 then return ("%g min"):format(minutes) end
+  return ("%ds"):format(math.floor(minutes * 60))
+end
+
+return M

--- a/hammerspoon/modules/ambient.lua
+++ b/hammerspoon/modules/ambient.lua
@@ -1,0 +1,138 @@
+-- Ambient sound loop. Reads the available moods from the contents of
+-- the ambient/ directory next to this file — no hardcoded list, no
+-- manifest. Drop a `.mp3` / `.wav` / `.m4a` / `.flac` in there and it
+-- becomes a mood after the next module reload (⌃⌥⌘M → ambient).
+--
+-- One sound plays at a time. Cycle order: off → first → second → ... →
+-- off. The button label in the timer popup shows the active mood; the
+-- hotkey works without a popup so you can start a soundtrack before
+-- starting a timer.
+
+local scanner = require("lib.ambient_scanner")
+
+local DIR = os.getenv("HOME") .. "/dotfiles/master/hammerspoon/ambient"
+
+local function stopSound(self)
+  if not self.sound then return end
+  pcall(function() self.sound:stop() end)
+  self.sound = nil
+end
+
+local function play(self, mood)
+  stopSound(self)
+  if not mood then self.current = nil; return end
+
+  local s = hs.sound.getByFile(mood.path)
+  if not s then
+    hs.alert.show("Couldn't load: " .. mood.name)
+    self.current = nil
+    return
+  end
+  s:loopSound(true)
+  s:volume(self.volume)
+  local ok = pcall(function() s:play() end)
+  if not ok then
+    hs.alert.show("Couldn't play: " .. mood.name)
+    self.current = nil
+    return
+  end
+  self.sound = s
+  self.current = mood
+end
+
+local function indexOfCurrent(self)
+  if not self.current then return 0 end
+  for i, m in ipairs(self.moods) do
+    if m.path == self.current.path then return i end
+  end
+  return 0
+end
+
+local function cycle(self)
+  if #self.moods == 0 then
+    hs.alert.show("No ambient sounds in " .. DIR)
+    return
+  end
+  local next_idx = indexOfCurrent(self) + 1
+  if next_idx > #self.moods then
+    play(self, nil)
+    hs.alert.show("♪ off")
+  else
+    local mood = self.moods[next_idx]
+    play(self, mood)
+    hs.alert.show("♪ " .. mood.name)
+  end
+end
+
+return {
+  name = "ambient",
+
+  start = function(ctx)
+    local self = {
+      ctx     = ctx,
+      moods   = scanner.scan(DIR, hs.fs.dir),
+      current = nil,
+      sound   = nil,
+      volume  = 0.6,
+    }
+
+    self._hotkey = ctx.track(hs.hotkey.bind(
+      {"ctrl", "alt", "cmd"}, "A", function() cycle(self) end
+    ))
+
+    -- Public methods the tooltip pulls via registry.get("ambient").
+    self.cycle = function() cycle(self) end
+    self.currentMood = function() return self.current and self.current.name or nil end
+    self.hasMoods = function() return #self.moods > 0 end
+
+    -- pause/resume are called by the timer module on timer pause/resume
+    -- so the soundscape follows session state. No-op when nothing plays.
+    self.pause = function()
+      if self.sound then pcall(function() self.sound:pause() end) end
+    end
+    self.resume = function()
+      if self.sound then pcall(function() self.sound:resume() end) end
+    end
+    self.off = function() play(self, nil) end
+
+    -- Spotlight-style picker. Escape leaves current playback alone — that
+    -- way you can dismiss without committing to a change. onDone fires
+    -- after the chooser closes (selection or Escape) so callers can defer
+    -- side-effects (e.g. starting a timer) until the user actually commits.
+    self.pick = function(onDone)
+      if #self.moods == 0 then if onDone then onDone() end; return end
+      local options = {
+        { text = "Off — silence", subText = "no ambient", uuid = "_off" },
+      }
+      for _, m in ipairs(self.moods) do
+        local marker = (self.current and self.current.path == m.path) and "  (current)" or ""
+        table.insert(options, { text = m.name .. marker, subText = m.path, uuid = m.path })
+      end
+      local chooser = hs.chooser.new(function(choice)
+        if choice then
+          if choice.uuid == "_off" then
+            play(self, nil)
+          else
+            for _, m in ipairs(self.moods) do
+              if m.path == choice.uuid then play(self, m); break end
+            end
+          end
+        end
+        if onDone then onDone() end
+      end)
+      chooser:choices(options)
+      chooser:placeholderText("Sound for this session…")
+      chooser:show()
+    end
+
+    return self
+  end,
+
+  stop = function(self) stopSound(self) end,
+
+  status = function(self)
+    if #self.moods == 0 then return "no sounds in ambient/" end
+    if not self.current then return ("off · %d available"):format(#self.moods) end
+    return self.current.name
+  end,
+}

--- a/hammerspoon/modules/calendar.lua
+++ b/hammerspoon/modules/calendar.lua
@@ -1,0 +1,62 @@
+-- Calendar source. Polls icalBuddy every CAL_REFRESH_SECONDS and exposes
+-- the current event (if any) via source(). Parsing lives in lib/ical_parser.
+
+local parser = require("lib.ical_parser")
+
+local CAL_REFRESH_SECONDS = 60
+local ICALBUDDY_PATH      = "/opt/homebrew/bin/icalBuddy"  -- "/usr/local/bin/icalBuddy" on Intel
+local MAX_EVENT_HOURS     = 20
+
+local CMD = ICALBUDDY_PATH ..
+  [[ -nc -nrd -b "" ]] ..
+  [[ -iep 'datetime,title' ]] ..
+  [[ -eep 'notes,url,location,attendees' ]] ..
+  [[ -df "%Y-%m-%d" -tf "%H:%M:%S" ]] ..
+  [[ -po 'datetime,title' eventsNow ]]
+
+local function runIcalBuddy()
+  local out, ok = hs.execute(CMD)
+  if not ok or not out or out == "" then return nil end
+  return out
+end
+
+local function refresh(self)
+  local raw = runIcalBuddy()
+  if not raw then self.current = nil; return end
+  self.current = parser.validateEvent(parser.parseOutput(raw), MAX_EVENT_HOURS)
+end
+
+return {
+  name = "calendar",
+
+  start = function(ctx)
+    local self = { current = nil }
+    refresh(self)
+    self._poll = ctx.track(hs.timer.doEvery(CAL_REFRESH_SECONDS, function()
+      refresh(self)
+    end))
+    return self
+  end,
+
+  stop = function(_self) end,  -- registry sweeps the timer
+
+  status = function(self)
+    if not self.current then return "no event" end
+    local left = self.current.endEpoch - os.time()
+    return ("%s · %dm left"):format(self.current.title, math.max(0, math.floor(left / 60)))
+  end,
+
+  source = function(self)
+    local e = self.current
+    if not e then return nil end
+    local now = os.time()
+    if now < e.startEpoch or now >= e.endEpoch then return nil end
+    return {
+      startEpoch = e.startEpoch,
+      endEpoch   = e.endEpoch,
+      title      = e.title,
+      kind       = "calendar",
+      priority   = 1,
+    }
+  end,
+}

--- a/hammerspoon/modules/progress_bar.lua
+++ b/hammerspoon/modules/progress_bar.lua
@@ -1,0 +1,134 @@
+-- Renderer. Consumes sources from the registry, picks the highest-priority
+-- one, and updates a thin always-on-top canvas. Knows nothing about timers
+-- or calendars — just frames, percentages, and colors.
+
+local BAR_HEIGHT = 3
+
+-- high = ≤10% remaining (red), mid = ≤25% remaining (orange), low = starting color.
+-- Warning colors (mid/high) are shared across sources; the starting color
+-- differs (blue for manual, green for calendar) so you can tell at a glance
+-- which source owns the bar before it heats up.
+local PALETTE = {
+  manual = {
+    high = { red = 0.95, green = 0.20, blue = 0.20, alpha = 0.95 },
+    mid  = { red = 1.00, green = 0.55, blue = 0.10, alpha = 0.95 },
+    low  = { red = 0.30, green = 0.55, blue = 0.85, alpha = 0.95 },
+  },
+  calendar = {
+    high = { red = 0.95, green = 0.20, blue = 0.20, alpha = 0.95 },
+    mid  = { red = 1.00, green = 0.55, blue = 0.10, alpha = 0.95 },
+    low  = { red = 0.40, green = 0.80, blue = 0.50, alpha = 0.95 },
+  },
+}
+
+local function pickColor(kind, pct)
+  local p = PALETTE[kind] or PALETTE.manual
+  if pct >= 0.90 then return p.high end   -- ≤10% remaining
+  if pct >= 0.75 then return p.mid  end   -- ≤25% remaining
+  return p.low
+end
+
+local function computeBarFrame(screen, position, height)
+  local f = screen:frame()
+  local y = (position == "top") and f.y or (f.y + f.h - height)
+  return { x = f.x, y = y, w = f.w, h = height }
+end
+
+local function makeCanvas(frame)
+  local c = hs.canvas.new(frame)
+  c:level(hs.canvas.windowLevels.overlay)
+  c:behavior({"canJoinAllSpaces", "stationary"})
+  c:clickActivating(false)
+  c[1] = {  -- background track
+    type = "rectangle", action = "fill",
+    fillColor = { red = 0, green = 0, blue = 0, alpha = 0.25 },
+    frame = { x = 0, y = 0, w = "100%", h = "100%" },
+  }
+  c[2] = {  -- filled portion
+    type = "rectangle", action = "fill",
+    fillColor = PALETTE.manual.low,
+    frame = { x = 0, y = 0, w = "0%", h = "100%" },
+  }
+  c:show()
+  return c
+end
+
+local function pickSource(list)
+  local best = nil
+  for _, s in ipairs(list) do
+    if not best or (s.priority or 0) > (best.priority or 0) then best = s end
+  end
+  return best
+end
+
+local function computeProgress(src, fallbackNow)
+  local now     = src.now or fallbackNow
+  local total   = src.endEpoch - src.startEpoch
+  local elapsed = now - src.startEpoch
+  local pct = elapsed / total
+  if pct < 0 then return 0 end
+  if pct > 1 then return 1 end
+  return pct
+end
+
+local function render(canvas, pct, color)
+  canvas:alpha(1.0)
+  canvas[2].frame = { x = 0, y = 0, w = tostring(pct * 100) .. "%", h = "100%" }
+  canvas[2].fillColor = color
+end
+
+local function clear(canvas)
+  canvas[2].frame = { x = 0, y = 0, w = "0%", h = "100%" }
+  canvas:alpha(0.0)
+end
+
+local function tick(self)
+  -- Let any source module fire its own one-shot completion side-effect.
+  local timer = self.ctx.registry.get("timer")
+  if timer and timer.fireExpiryIfDue then timer.fireExpiryIfDue() end
+
+  local src = pickSource(self.ctx.registry.sources())
+  if not src then clear(self.canvas); return end
+  local pct = computeProgress(src, os.time())
+  render(self.canvas, pct, pickColor(src.kind, pct))
+end
+
+return {
+  name = "progress_bar",
+
+  start = function(ctx)
+    local position = ctx.config.BAR_POSITION
+    local tickSecs = ctx.config.TICK_SECONDS
+
+    local self = { ctx = ctx }
+    self.canvas = ctx.track(makeCanvas(
+      computeBarFrame(hs.screen.primaryScreen(), position, BAR_HEIGHT)
+    ))
+
+    self._tick = ctx.track(hs.timer.doEvery(tickSecs, function()
+      local ok, err = pcall(tick, self)
+      if not ok then ctx.log("tick error: " .. tostring(err)) end
+    end))
+
+    self._screenWatcher = ctx.track(hs.screen.watcher.new(function()
+      pcall(function() self.canvas:delete() end)
+      self.canvas = ctx.track(makeCanvas(
+        computeBarFrame(hs.screen.primaryScreen(), position, BAR_HEIGHT)
+      ))
+    end))
+    self._screenWatcher:start()
+
+    return self
+  end,
+
+  stop = function(self)
+    if self.canvas then
+      pcall(function() self.canvas:delete() end)
+      self.canvas = nil
+    end
+  end,
+
+  status = function(_self)
+    return ("h=%dpx · tick=%ds"):format(BAR_HEIGHT, 1)
+  end,
+}

--- a/hammerspoon/modules/timer.lua
+++ b/hammerspoon/modules/timer.lua
@@ -1,0 +1,120 @@
+-- Manual countdown timer. Owns its hotkeys and a one-shot expiry
+-- notification. Exposes a snapshot via source() that progress_bar reads
+-- and a control surface (stop/pause/resume) that tooltip invokes.
+
+local parser = require("lib.timer_parser")
+
+local function editPreset(self)
+  if not self.active then return "" end
+  local now = self.pausedAt or os.time()
+  local remaining = math.max(1, math.ceil((self.active.endEpoch - now) / 60))
+  return ("%d %s"):format(remaining, self.active.title)
+end
+
+local function prompt(self, preset)
+  local btn, text = hs.dialog.textPrompt(
+    "Manual timer",
+    "Examples:  25  ·  25 deep work  ·  1h30  ·  1:30  ·  90s",
+    preset or "", "Start", "Cancel"
+  )
+  if btn ~= "Start" then return end
+
+  local minutes, title = parser.parseInput(text)
+  if not minutes then
+    hs.alert.show("Couldn't parse: " .. tostring(text))
+    return
+  end
+
+  local now = os.time()
+  self.active = {
+    startEpoch = now,
+    endEpoch   = now + math.floor(minutes * 60),
+    title      = title,
+  }
+  self.pausedAt = nil
+  self.expiredFired = false
+  hs.alert.show(("⏱  %s · %s"):format(title, parser.durationLabel(minutes)))
+end
+
+local function stop(self, silent)
+  if not self.active then return end
+  self.active = nil
+  self.pausedAt = nil
+  if not silent then hs.alert.show("Timer cancelled") end
+end
+
+local function pause(self)
+  if not self.active or self.pausedAt then return end
+  self.pausedAt = os.time()
+  hs.alert.show("⏸  Paused")
+end
+
+local function resume(self)
+  if not self.active or not self.pausedAt then return end
+  local elapsedPause = os.time() - self.pausedAt
+  self.active.endEpoch = self.active.endEpoch + elapsedPause
+  self.pausedAt = nil
+  hs.alert.show("▶  Resumed")
+end
+
+return {
+  name = "timer",
+
+  start = function(ctx)
+    local self = { active = nil, pausedAt = nil, expiredFired = false }
+
+    self._startHotkey = ctx.track(hs.hotkey.bind(
+      {"ctrl", "alt", "cmd"}, "T", function() prompt(self) end
+    ))
+    self._cancelHotkey = ctx.track(hs.hotkey.bind(
+      {"ctrl", "alt", "cmd"}, ".", function() stop(self) end
+    ))
+
+    self.fireExpiryIfDue = function()
+      if not self.active or self.pausedAt then return false end
+      if os.time() < self.active.endEpoch then return false end
+      if self.expiredFired then return false end
+      hs.notify.new({
+        title           = "Timer done",
+        informativeText = self.active.title,
+        soundName       = hs.notify.defaultNotificationSound,
+      }):send()
+      self.expiredFired = true
+      self.active = nil
+      return true
+    end
+
+    return self
+  end,
+
+  stop = function(_self) end,  -- registry sweeps the hotkeys
+
+  status = function(self)
+    if not self.active then return "idle" end
+    if self.pausedAt then return ("%s · paused"):format(self.active.title) end
+    local remaining = self.active.endEpoch - os.time()
+    if remaining < 0 then remaining = 0 end
+    return ("%s · %ds left"):format(self.active.title, remaining)
+  end,
+
+  source = function(self)
+    local a = self.active
+    if not a then return nil end
+    if not self.pausedAt and os.time() >= a.endEpoch then return nil end
+    return {
+      startEpoch = a.startEpoch,
+      endEpoch   = a.endEpoch,
+      title      = a.title,
+      kind       = "manual",
+      priority   = 10,                          -- manual wins over calendar
+      now        = self.pausedAt,               -- nil ⇒ live clock; set ⇒ frozen
+      paused     = self.pausedAt ~= nil,
+      actions = {
+        edit   = function() prompt(self, editPreset(self)) end,
+        stop   = function() stop(self) end,
+        pause  = (not self.pausedAt) and function() pause(self) end  or nil,
+        resume = (self.pausedAt)     and function() resume(self) end or nil,
+      },
+    }
+  end,
+}

--- a/hammerspoon/modules/timer.lua
+++ b/hammerspoon/modules/timer.lua
@@ -4,6 +4,10 @@
 
 local parser = require("lib.timer_parser")
 
+local function ambientModule(self)
+  return self.ctx and self.ctx.registry.get("ambient") or nil
+end
+
 local function editPreset(self)
   if not self.active then return "" end
   local now = self.pausedAt or os.time()
@@ -25,35 +29,57 @@ local function prompt(self, preset)
     return
   end
 
-  local now = os.time()
-  self.active = {
-    startEpoch = now,
-    endEpoch   = now + math.floor(minutes * 60),
-    title      = title,
-  }
-  self.pausedAt = nil
-  self.expiredFired = false
-  hs.alert.show(("⏱  %s · %s"):format(title, parser.durationLabel(minutes)))
+  -- Snapshot the duration/title now, but start the clock only after any
+  -- mood picker closes — otherwise the user "loses" the picker time.
+  local function commit()
+    local now = os.time()
+    self.active = {
+      startEpoch = now,
+      endEpoch   = now + math.floor(minutes * 60),
+      title      = title,
+    }
+    self.pausedAt = nil
+    self.expiredFired = false
+    hs.alert.show(("⏱  %s · %s"):format(title, parser.durationLabel(minutes)))
+  end
+
+  local amb = ambientModule(self)
+  if preset == nil and amb and amb.hasMoods() and amb.pick then
+    amb.pick(commit)
+  else
+    commit()
+  end
 end
 
 local function stop(self, silent)
   if not self.active then return end
   self.active = nil
   self.pausedAt = nil
+  local amb = ambientModule(self)
+  if amb and amb.off then amb.off() end
   if not silent then hs.alert.show("Timer cancelled") end
 end
 
 local function pause(self)
   if not self.active or self.pausedAt then return end
   self.pausedAt = os.time()
+  local amb = ambientModule(self)
+  if amb and amb.pause then amb.pause() end
   hs.alert.show("⏸  Paused")
 end
 
 local function resume(self)
   if not self.active or not self.pausedAt then return end
+  -- Shift the entire window forward by the paused interval. Just bumping
+  -- endEpoch would keep `elapsed = now - startEpoch` ticking through the
+  -- paused seconds, so the popup jumps from "0:08 elapsed" → "0:13"
+  -- on resume even though no work-time passed.
   local elapsedPause = os.time() - self.pausedAt
-  self.active.endEpoch = self.active.endEpoch + elapsedPause
+  self.active.startEpoch = self.active.startEpoch + elapsedPause
+  self.active.endEpoch   = self.active.endEpoch   + elapsedPause
   self.pausedAt = nil
+  local amb = ambientModule(self)
+  if amb and amb.resume then amb.resume() end
   hs.alert.show("▶  Resumed")
 end
 
@@ -61,7 +87,7 @@ return {
   name = "timer",
 
   start = function(ctx)
-    local self = { active = nil, pausedAt = nil, expiredFired = false }
+    local self = { ctx = ctx, active = nil, pausedAt = nil, expiredFired = false }
 
     self._startHotkey = ctx.track(hs.hotkey.bind(
       {"ctrl", "alt", "cmd"}, "T", function() prompt(self) end

--- a/hammerspoon/modules/tooltip.lua
+++ b/hammerspoon/modules/tooltip.lua
@@ -1,0 +1,241 @@
+-- Hover tooltip + control surface. Reads the active source from the
+-- registry, shows title / elapsed / remaining, and renders buttons for
+-- whichever actions the source exposes (timer: Pause/Resume + Stop;
+-- calendar: info only).
+--
+-- Two canvases:
+--   hotZone — small invisible mouse-aware region at the screen corner
+--   popup   — appears on hover, refreshed each tick
+
+local duration = require("lib.duration")
+
+local HOT_W      = 120
+local HOT_H      = 28
+local POPUP_W    = 260
+local POPUP_H    = 92
+local CORNER_PAD = 4
+local REFRESH    = 0.15  -- s between cursor polls / popup refreshes
+
+local function hotZoneFrame(screen, position)
+  local f = screen:frame()
+  if position == "top" then
+    return { x = f.x + CORNER_PAD, y = f.y, w = HOT_W, h = HOT_H }
+  end
+  return { x = f.x + CORNER_PAD, y = f.y + f.h - HOT_H, w = HOT_W, h = HOT_H }
+end
+
+local function popupFrame(screen, position)
+  local f = screen:frame()
+  if position == "top" then
+    return { x = f.x + CORNER_PAD, y = f.y + HOT_H, w = POPUP_W, h = POPUP_H }
+  end
+  return { x = f.x + CORNER_PAD, y = f.y + f.h - HOT_H - POPUP_H, w = POPUP_W, h = POPUP_H }
+end
+
+local function makeHotZone(frame, onEnter)
+  -- Hot zone is at popUpMenu level (above the bar) so that the bar's
+  -- per-tick redraw at overlay level can't shadow it and cause spurious
+  -- mouseExit events. We only use mouseEnter for instant show; hide is
+  -- driven by absolute-position polling in the refresh tick.
+  local c = hs.canvas.new(frame)
+  c:level(hs.canvas.windowLevels.popUpMenu)
+  c:behavior({"canJoinAllSpaces", "stationary"})
+  c:clickActivating(false)
+  c[1] = {
+    type = "rectangle", action = "fill",
+    fillColor = { white = 1, alpha = 0.001 },  -- effectively invisible, still hit-testable
+    frame = { x = 0, y = 0, w = "100%", h = "100%" },
+    trackMouseEnterExit = true,
+    id = "hot",
+  }
+  c:canvasMouseEvents(false, false, true, false)
+  c:mouseCallback(function(_, message)
+    if message == "mouseEnter" then onEnter() end
+  end)
+  c:show()
+  return c
+end
+
+local function buildPopup(frame, onClick)
+  local c = hs.canvas.new(frame)
+  c:level(hs.canvas.windowLevels.popUpMenu)
+  c:behavior({"canJoinAllSpaces", "stationary"})
+  c:clickActivating(false)
+  c[1] = {  -- background plate
+    type = "rectangle", action = "fill",
+    fillColor = { white = 0.10, alpha = 0.93 },
+    strokeColor = { white = 0.30, alpha = 0.6 },
+    strokeWidth = 1,
+    roundedRectRadii = { xRadius = 8, yRadius = 8 },
+    frame = { x = 0, y = 0, w = "100%", h = "100%" },
+    id = "bg",
+  }
+  c:canvasMouseEvents(true, false, false, false)
+  c:mouseCallback(function(_, message, id)
+    if message == "mouseDown" then onClick(id) end
+  end)
+  return c
+end
+
+local function clearButtons(c)
+  -- Keep elements 1..3 (bg, title, line2). Remove anything after.
+  while c:elementCount() > 3 do c:removeElement(c:elementCount()) end
+end
+
+local function appendButton(c, x, y, w, h, id, label)
+  c:appendElements({
+    type = "rectangle", action = "fill",
+    fillColor = { white = 0.22, alpha = 0.95 },
+    strokeColor = { white = 0.40, alpha = 0.9 },
+    strokeWidth = 1,
+    roundedRectRadii = { xRadius = 5, yRadius = 5 },
+    frame = { x = x, y = y, w = w, h = h },
+    trackMouseDown = true,
+    id = "btn:" .. id,
+  })
+  c:appendElements({
+    type = "text", text = label,
+    textColor = { white = 0.98 },
+    textSize = 12,
+    textAlignment = "center",
+    frame = { x = x, y = y + 4, w = w, h = h - 6 },
+  })
+end
+
+local function refreshPopup(c, src)
+  local now      = src.now or os.time()
+  local total    = src.endEpoch - src.startEpoch
+  local elapsed  = math.max(0, math.min(total, now - src.startEpoch))
+  local left     = total - elapsed
+  local pausedTag = src.paused and "  ·  paused" or ""
+
+  c[2] = {
+    type = "text",
+    text = src.title or "",
+    textColor = { white = 0.98 },
+    textSize = 14,
+    textFont = ".AppleSystemUIFont",
+    frame = { x = 12, y = 8, w = POPUP_W - 24, h = 20 },
+  }
+  c[3] = {
+    type = "text",
+    text = ("%s elapsed  ·  %s left%s"):format(
+      duration.formatHMS(elapsed),
+      duration.formatHMS(left),
+      pausedTag
+    ),
+    textColor = { white = 0.72 },
+    textSize = 11,
+    frame = { x = 12, y = 30, w = POPUP_W - 24, h = 16 },
+  }
+
+  clearButtons(c)
+  local actions = src.actions or {}
+  local layout = { y = 54, h = 26, w = 70, gap = 8, x = 12 }
+  if actions.edit   then appendButton(c, layout.x, layout.y, layout.w, layout.h, "edit",   "Edit");   layout.x = layout.x + layout.w + layout.gap end
+  if actions.pause  then appendButton(c, layout.x, layout.y, layout.w, layout.h, "pause",  "Pause");  layout.x = layout.x + layout.w + layout.gap end
+  if actions.resume then appendButton(c, layout.x, layout.y, layout.w, layout.h, "resume", "Resume"); layout.x = layout.x + layout.w + layout.gap end
+  if actions.stop   then appendButton(c, layout.x, layout.y, layout.w, layout.h, "stop",   "Stop")   end
+end
+
+local function activeSource(registry)
+  local best
+  for _, s in ipairs(registry.sources()) do
+    if not best or (s.priority or 0) > (best.priority or 0) then best = s end
+  end
+  return best
+end
+
+local function showIfSource(self)
+  local src = activeSource(self.ctx.registry)
+  if not src then return end
+  refreshPopup(self.popup, src)
+  self.popup:show()
+  self.visible = true
+end
+
+local function hidePopup(self)
+  if not self.visible then return end
+  self.popup:hide()
+  self.visible = false
+end
+
+local function pointInFrame(p, f)
+  return p.x >= f.x and p.x <= f.x + f.w
+     and p.y >= f.y and p.y <= f.y + f.h
+end
+
+local function cursorOverEitherFrame(self)
+  local p = hs.mouse.absolutePosition()
+  return pointInFrame(p, self.hotFrame) or pointInFrame(p, self.popupFrame)
+end
+
+local function handleClick(self, id)
+  local src = activeSource(self.ctx.registry)
+  if not src or not src.actions then return end
+  local key = id and id:match("^btn:(.+)$")
+  local fn = key and src.actions[key]
+  if fn then
+    fn()
+    -- Re-render immediately so Pause flips to Resume without waiting a tick.
+    showIfSource(self)
+  end
+end
+
+return {
+  name = "tooltip",
+
+  start = function(ctx)
+    local position = ctx.config.BAR_POSITION
+    local screen   = hs.screen.primaryScreen()
+
+    local self = {
+      ctx        = ctx,
+      visible    = false,
+      hotFrame   = hotZoneFrame(screen, position),
+      popupFrame = popupFrame(screen, position),
+    }
+
+    self.hotZone = ctx.track(makeHotZone(
+      self.hotFrame,
+      function() showIfSource(self) end
+    ))
+
+    self.popup = ctx.track(buildPopup(
+      self.popupFrame,
+      function(id) handleClick(self, id) end
+    ))
+
+    -- Drive visibility from the real cursor position. Per-tick polling
+    -- sidesteps the spurious mouseExit events the bar's overlay redraw
+    -- triggers on the hot zone every second.
+    self._refresh = ctx.track(hs.timer.doEvery(REFRESH, function()
+      local over = cursorOverEitherFrame(self)
+      if not over then
+        if self.visible then hidePopup(self) end
+        return
+      end
+      local src = activeSource(ctx.registry)
+      if not src then
+        if self.visible then hidePopup(self) end
+        return
+      end
+      if not self.visible then
+        self.popup:show()
+        self.visible = true
+      end
+      pcall(refreshPopup, self.popup, src)
+    end))
+
+    return self
+  end,
+
+  stop = function(self)
+    if self.popup   then pcall(function() self.popup:delete()   end); self.popup   = nil end
+    if self.hotZone then pcall(function() self.hotZone:delete() end); self.hotZone = nil end
+  end,
+
+  status = function(self)
+    return self.visible and "visible" or "idle"
+  end,
+}

--- a/hammerspoon/modules/tooltip.lua
+++ b/hammerspoon/modules/tooltip.lua
@@ -11,7 +11,7 @@ local duration = require("lib.duration")
 
 local HOT_W      = 120
 local HOT_H      = 28
-local POPUP_W    = 260
+local POPUP_W    = 320
 local POPUP_H    = 92
 local CORNER_PAD = 4
 local REFRESH    = 0.15  -- s between cursor polls / popup refreshes
@@ -102,7 +102,7 @@ local function appendButton(c, x, y, w, h, id, label)
   })
 end
 
-local function refreshPopup(c, src)
+local function refreshPopup(c, src, ambient)
   local now      = src.now or os.time()
   local total    = src.endEpoch - src.startEpoch
   local elapsed  = math.max(0, math.min(total, now - src.startEpoch))
@@ -132,10 +132,17 @@ local function refreshPopup(c, src)
   clearButtons(c)
   local actions = src.actions or {}
   local layout = { y = 54, h = 26, w = 70, gap = 8, x = 12 }
-  if actions.edit   then appendButton(c, layout.x, layout.y, layout.w, layout.h, "edit",   "Edit");   layout.x = layout.x + layout.w + layout.gap end
-  if actions.pause  then appendButton(c, layout.x, layout.y, layout.w, layout.h, "pause",  "Pause");  layout.x = layout.x + layout.w + layout.gap end
-  if actions.resume then appendButton(c, layout.x, layout.y, layout.w, layout.h, "resume", "Resume"); layout.x = layout.x + layout.w + layout.gap end
-  if actions.stop   then appendButton(c, layout.x, layout.y, layout.w, layout.h, "stop",   "Stop")   end
+  local function place(id, label)
+    appendButton(c, layout.x, layout.y, layout.w, layout.h, id, label)
+    layout.x = layout.x + layout.w + layout.gap
+  end
+  if actions.edit                       then place("edit",   "Edit")   end
+  if actions.pause                      then place("pause",  "Pause")  end
+  if actions.resume                     then place("resume", "Resume") end
+  if actions.stop                       then place("stop",   "Stop")   end
+  if ambient and ambient.hasMoods() then
+    place("ambient", "♪ " .. (ambient.currentMood() or "off"))
+  end
 end
 
 local function activeSource(registry)
@@ -149,7 +156,7 @@ end
 local function showIfSource(self)
   local src = activeSource(self.ctx.registry)
   if not src then return end
-  refreshPopup(self.popup, src)
+  refreshPopup(self.popup, src, self.ctx.registry.get("ambient"))
   self.popup:show()
   self.visible = true
 end
@@ -171,10 +178,19 @@ local function cursorOverEitherFrame(self)
 end
 
 local function handleClick(self, id)
+  local key = id and id:match("^btn:(.+)$")
+  if not key then return end
+
+  if key == "ambient" then
+    local ambient = self.ctx.registry.get("ambient")
+    if ambient then ambient.cycle() end
+    showIfSource(self)
+    return
+  end
+
   local src = activeSource(self.ctx.registry)
   if not src or not src.actions then return end
-  local key = id and id:match("^btn:(.+)$")
-  local fn = key and src.actions[key]
+  local fn = src.actions[key]
   if fn then
     fn()
     -- Re-render immediately so Pause flips to Resume without waiting a tick.
@@ -224,7 +240,7 @@ return {
         self.popup:show()
         self.visible = true
       end
-      pcall(refreshPopup, self.popup, src)
+      pcall(refreshPopup, self.popup, src, ctx.registry.get("ambient"))
     end))
 
     return self

--- a/hammerspoon/spec/ambient_scanner_spec.lua
+++ b/hammerspoon/spec/ambient_scanner_spec.lua
@@ -1,0 +1,59 @@
+local T = require("spec.harness")
+local scanner = require("lib.ambient_scanner")
+
+T.describe("ambient_scanner")
+
+-- Build a fake hs.fs.dir-style iterator factory from a hardcoded file list.
+local function fakeLister(files)
+  return function(_dir)
+    local i = 0
+    return function()
+      i = i + 1
+      return files[i]
+    end
+  end
+end
+
+T.test("filters out unsupported extensions", function()
+  local list = fakeLister({ ".", "..", "rain.mp3", "notes.txt", "song.exe", "wind.wav" })
+  local out = scanner.scan("/x", list)
+  T.eq(#out, 2)
+  T.eq(out[1].name, "rain")
+  T.eq(out[2].name, "wind")
+end)
+
+T.test("prettifies underscores and hyphens to spaces", function()
+  local list = fakeLister({ "coffee_shop.mp3", "soft-storm.m4a" })
+  local out = scanner.scan("/x", list)
+  T.eq(out[1].name, "coffee shop")
+  T.eq(out[2].name, "soft storm")
+end)
+
+T.test("sorts alphabetically by display name", function()
+  local list = fakeLister({ "wind.wav", "cafe.mp3", "rain.mp3" })
+  local out = scanner.scan("/x", list)
+  T.eq(out[1].name, "cafe")
+  T.eq(out[2].name, "rain")
+  T.eq(out[3].name, "wind")
+end)
+
+T.test("attaches absolute path from dir + filename", function()
+  local list = fakeLister({ "rain.mp3" })
+  local out = scanner.scan("/sounds", list)
+  T.eq(out[1].path, "/sounds/rain.mp3")
+end)
+
+T.test("returns empty list when iterator throws", function()
+  local out = scanner.scan("/nope", function() error("ENOENT") end)
+  T.eq(#out, 0)
+end)
+
+T.test("returns empty list for empty directory", function()
+  local out = scanner.scan("/x", fakeLister({ ".", ".." }))
+  T.eq(#out, 0)
+end)
+
+T.test("extension match is case-insensitive", function()
+  local out = scanner.scan("/x", fakeLister({ "RAIN.MP3", "Wind.Wav" }))
+  T.eq(#out, 2)
+end)

--- a/hammerspoon/spec/duration_spec.lua
+++ b/hammerspoon/spec/duration_spec.lua
@@ -1,0 +1,30 @@
+local T = require("spec.harness")
+local D = require("lib.duration")
+
+T.describe("duration")
+
+T.test("seconds under a minute", function()
+  T.eq(D.formatHMS(0),  "0:00")
+  T.eq(D.formatHMS(5),  "0:05")
+  T.eq(D.formatHMS(59), "0:59")
+end)
+
+T.test("minutes:seconds", function()
+  T.eq(D.formatHMS(60),   "1:00")
+  T.eq(D.formatHMS(201),  "3:21")
+  T.eq(D.formatHMS(3599), "59:59")
+end)
+
+T.test("hours:minutes:seconds", function()
+  T.eq(D.formatHMS(3600), "1:00:00")
+  T.eq(D.formatHMS(5025), "1:23:45")
+end)
+
+T.test("nil / negative coerce to zero", function()
+  T.eq(D.formatHMS(nil),  "0:00")
+  T.eq(D.formatHMS(-100), "0:00")
+end)
+
+T.test("non-integer floors", function()
+  T.eq(D.formatHMS(201.9), "3:21")
+end)

--- a/hammerspoon/spec/harness.lua
+++ b/hammerspoon/spec/harness.lua
@@ -1,0 +1,60 @@
+-- Tiny test harness. No deps. Specs register with T.test(name, fn) and
+-- assert via T.eq / T.is_nil / T.truthy. Exit code is 0 on green, 1 on
+-- any failure — fits CI without extra glue.
+
+local T = { _suite = "", _tests = {}, _pass = 0, _fail = 0, _failures = {} }
+
+function T.describe(suite) T._suite = suite end
+
+function T.test(name, fn)
+  T._tests[#T._tests + 1] = { suite = T._suite, name = name, fn = fn }
+end
+
+local function repr(v)
+  if type(v) == "string" then return ("%q"):format(v) end
+  if type(v) == "table"  then return "<table>" end
+  return tostring(v)
+end
+
+function T.eq(actual, expected, ...)
+  -- Multi-return support: T.eq(parseInput("25"), 25, "Focus")
+  local extras = { ... }
+  if #extras > 0 then
+    if actual ~= expected then
+      error(("expected %s, got %s"):format(repr(expected), repr(actual)), 2)
+    end
+    return
+  end
+  if actual ~= expected then
+    error(("expected %s, got %s"):format(repr(expected), repr(actual)), 2)
+  end
+end
+
+function T.is_nil(actual)
+  if actual ~= nil then
+    error(("expected nil, got %s"):format(repr(actual)), 2)
+  end
+end
+
+function T.truthy(actual)
+  if not actual then error("expected truthy, got " .. repr(actual), 2) end
+end
+
+function T.run()
+  for _, t in ipairs(T._tests) do
+    local ok, err = pcall(t.fn)
+    local label = ("%s · %s"):format(t.suite, t.name)
+    if ok then
+      T._pass = T._pass + 1
+      print("PASS  " .. label)
+    else
+      T._fail = T._fail + 1
+      T._failures[#T._failures + 1] = label .. " — " .. tostring(err)
+      print("FAIL  " .. label .. " — " .. tostring(err))
+    end
+  end
+  print(("\n%d passed, %d failed"):format(T._pass, T._fail))
+  os.exit(T._fail == 0 and 0 or 1)
+end
+
+return T

--- a/hammerspoon/spec/ical_parser_spec.lua
+++ b/hammerspoon/spec/ical_parser_spec.lua
@@ -1,0 +1,102 @@
+local T = require("spec.harness")
+local P = require("lib.ical_parser")
+
+T.describe("ical_parser")
+
+local LONG_FORMAT = [[
+2026-05-24 14:30:00 - 2026-05-24 15:00:00
+    Team standup
+]]
+
+local SHORT_FORMAT = [[
+2026-05-24 14:30:00 - 15:00:00
+    Quick sync
+]]
+
+local ALL_DAY = [[
+2026-05-24 00:00:00 - 2026-05-25 00:00:00
+    Office Hours
+]]
+
+T.test("parseDate roundtrips a known timestamp", function()
+  local epoch = P.parseDate("2026-05-24 14:30:00")
+  T.truthy(epoch)
+  -- Re-parse via os.date should give back the same fields.
+  local t = os.date("*t", epoch)
+  T.eq(t.year, 2026); T.eq(t.month, 5); T.eq(t.day, 24)
+  T.eq(t.hour, 14); T.eq(t.min, 30); T.eq(t.sec, 0)
+end)
+
+T.test("parseDate returns nil on garbage", function()
+  T.is_nil(P.parseDate(""))
+  T.is_nil(P.parseDate("not a date"))
+  T.is_nil(P.parseDate(nil))
+end)
+
+T.test("tryLongFormat extracts both endpoints", function()
+  local s, e = P.tryLongFormat(LONG_FORMAT)
+  T.eq(s, "2026-05-24 14:30:00")
+  T.eq(e, "2026-05-24 15:00:00")
+end)
+
+T.test("tryLongFormat returns nil on short-form input", function()
+  T.is_nil(P.tryLongFormat(SHORT_FORMAT))
+end)
+
+T.test("tryShortFormat handles single-date + two times", function()
+  local s, e = P.tryShortFormat(SHORT_FORMAT)
+  T.eq(s, "2026-05-24 14:30:00")
+  T.eq(e, "2026-05-24 15:00:00")
+end)
+
+T.test("extractTitle pulls the indented title line", function()
+  T.eq(P.extractTitle(LONG_FORMAT),  "Team standup")
+  T.eq(P.extractTitle(SHORT_FORMAT), "Quick sync")
+end)
+
+T.test("extractTitle falls back to 'event' when missing", function()
+  T.eq(P.extractTitle("2026-05-24 14:30:00 - 2026-05-24 15:00:00"), "event")
+end)
+
+T.test("parseOutput returns full event for long format", function()
+  local evt = P.parseOutput(LONG_FORMAT)
+  T.truthy(evt)
+  T.eq(evt.title, "Team standup")
+  T.truthy(evt.startEpoch); T.truthy(evt.endEpoch)
+  T.eq(evt.endEpoch - evt.startEpoch, 30 * 60)  -- 30 min
+end)
+
+T.test("parseOutput returns full event for short format", function()
+  local evt = P.parseOutput(SHORT_FORMAT)
+  T.truthy(evt)
+  T.eq(evt.title, "Quick sync")
+  T.eq(evt.endEpoch - evt.startEpoch, 30 * 60)
+end)
+
+T.test("parseOutput nil on empty / unmatched", function()
+  T.is_nil(P.parseOutput(""))
+  T.is_nil(P.parseOutput(nil))
+  T.is_nil(P.parseOutput("no dates here"))
+end)
+
+T.test("validateEvent passes a normal event", function()
+  local evt = P.parseOutput(LONG_FORMAT)
+  T.truthy(P.validateEvent(evt, 20))
+end)
+
+T.test("validateEvent rejects all-day blocks past maxHours", function()
+  local evt = P.parseOutput(ALL_DAY)
+  T.truthy(evt)            -- parse succeeded
+  T.is_nil(P.validateEvent(evt, 20))  -- but 24h > 20h cap
+end)
+
+T.test("validateEvent rejects nil / inverted / zero-length", function()
+  T.is_nil(P.validateEvent(nil, 20))
+  T.is_nil(P.validateEvent({ startEpoch = 100, endEpoch = 100 }, 20))
+  T.is_nil(P.validateEvent({ startEpoch = 200, endEpoch = 100 }, 20))
+end)
+
+T.test("validateEvent defaults maxHours to 20 when omitted", function()
+  local evt = P.parseOutput(ALL_DAY)
+  T.is_nil(P.validateEvent(evt))
+end)

--- a/hammerspoon/spec/run.lua
+++ b/hammerspoon/spec/run.lua
@@ -1,0 +1,24 @@
+-- Entry point. Adds the project root to package.path so `lib.*` and
+-- `spec.*` resolve, then loads every *_spec.lua next to it and runs.
+--
+-- Usage:  lua spec/run.lua
+
+local function projectRoot()
+  local here = arg[0]:match("(.*/)") or "./"
+  return here .. ".."
+end
+
+local root = projectRoot()
+package.path = table.concat({
+  root .. "/?.lua",
+  root .. "/?/init.lua",
+  package.path,
+}, ";")
+
+local T = require("spec.harness")
+
+require("spec.timer_parser_spec")
+require("spec.ical_parser_spec")
+require("spec.duration_spec")
+
+T.run()

--- a/hammerspoon/spec/run.lua
+++ b/hammerspoon/spec/run.lua
@@ -20,5 +20,6 @@ local T = require("spec.harness")
 require("spec.timer_parser_spec")
 require("spec.ical_parser_spec")
 require("spec.duration_spec")
+require("spec.ambient_scanner_spec")
 
 T.run()

--- a/hammerspoon/spec/timer_parser_spec.lua
+++ b/hammerspoon/spec/timer_parser_spec.lua
@@ -1,0 +1,75 @@
+local T = require("spec.harness")
+local P = require("lib.timer_parser")
+
+T.describe("timer_parser")
+
+T.test("bare minutes", function()
+  local m, label = P.parseInput("25")
+  T.eq(m, 25); T.eq(label, "Focus")
+end)
+
+T.test("bare minutes with label", function()
+  local m, label = P.parseInput("25 deep work")
+  T.eq(m, 25); T.eq(label, "deep work")
+end)
+
+T.test("colon form", function()
+  local m, label = P.parseInput("1:30")
+  T.eq(m, 90); T.eq(label, "Focus")
+end)
+
+T.test("hour-minute compact (1h30)", function()
+  local m = P.parseInput("1h30")
+  T.eq(m, 90)
+end)
+
+T.test("hour-minute with m suffix (1h30m)", function()
+  local m = P.parseInput("1h30m")
+  T.eq(m, 90)
+end)
+
+T.test("hour only (2h)", function()
+  local m = P.parseInput("2h")
+  T.eq(m, 120)
+end)
+
+T.test("minutes with m suffix (45m)", function()
+  local m = P.parseInput("45m")
+  T.eq(m, 45)
+end)
+
+T.test("seconds form (90s = 1.5 min)", function()
+  local m = P.parseInput("90s")
+  T.eq(m, 1.5)
+end)
+
+T.test("empty input returns nil", function()
+  T.is_nil(P.parseInput(""))
+  T.is_nil(P.parseInput("   "))
+  T.is_nil(P.parseInput(nil))
+end)
+
+T.test("garbage input returns nil", function()
+  T.is_nil(P.parseInput("abc"))
+  T.is_nil(P.parseInput("0"))           -- zero is rejected
+end)
+
+T.test("trims surrounding whitespace", function()
+  local m, label = P.parseInput("  25 deep work  ")
+  T.eq(m, 25); T.eq(label, "deep work")
+end)
+
+T.test("multi-word label preserved", function()
+  local _, label = P.parseInput("25 read the paper")
+  T.eq(label, "read the paper")
+end)
+
+T.test("durationLabel formats minutes", function()
+  T.eq(P.durationLabel(25),   "25 min")
+  T.eq(P.durationLabel(1.5),  "1.5 min")
+end)
+
+T.test("durationLabel formats sub-minute as seconds", function()
+  T.eq(P.durationLabel(0.5),  "30s")
+  T.eq(P.durationLabel(0.25), "15s")
+end)


### PR DESCRIPTION
## Summary
- Bootstrap Hammerspoon `init.lua` with a module registry and chooser bound to `ctrl+alt+cmd+M`
- Adds modules: `timer`, `calendar`, `progress_bar`, `tooltip`
- Adds `lib/` helpers: `duration`, `ical_parser`, `timer_parser`
- Adds a minimal `spec/` harness with tests for duration, iCal parser, and timer parser

## Test plan
- [ ] Symlink/copy `hammerspoon/` to `~/.hammerspoon/` and reload — confirm chooser opens via `ctrl+alt+cmd+M`
- [ ] Run `hammerspoon/spec/run.lua` and verify all specs pass
- [ ] Trigger each module from the chooser and confirm no errors in the Hammerspoon console